### PR TITLE
Add registration/login scaffolds

### DIFF
--- a/code/backend/README.md
+++ b/code/backend/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+A FastAPI backend providing registration and login endpoints.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure the database by setting the `DATABASE_URL` environment variable. By default, it uses SQLite `test.db`.
+3. Start the server:
+   ```bash
+   uvicorn app:app --reload
+   ```

--- a/code/backend/app.py
+++ b/code/backend/app.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .database import SessionLocal, engine, Base
+from . import models, schemas, crud
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+# Dependency
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post("/register")
+def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = crud.get_user_by_username(db, username=user.username)
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    return crud.create_user(db=db, user=user)
+
+@app.post("/login")
+def login(user: schemas.UserLogin, db: Session = Depends(get_db)):
+    db_user = crud.authenticate_user(db, username=user.username, password=user.password)
+    if not db_user:
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    return {"message": "Login successful"}

--- a/code/backend/crud.py
+++ b/code/backend/crud.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from . import models, schemas
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_user_by_username(db: Session, username: str):
+    return db.query(models.User).filter(models.User.username == username).first()
+
+def create_user(db: Session, user: schemas.UserCreate):
+    hashed_password = get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed_password)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+def authenticate_user(db: Session, username: str, password: str):
+    user = get_user_by_username(db, username)
+    if user and verify_password(password, user.hashed_password):
+        return user
+    return None

--- a/code/backend/database.py
+++ b/code/backend/database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/code/backend/models.py
+++ b/code/backend/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, index=True, nullable=False)
+    hashed_password = Column(String(128), nullable=False)

--- a/code/backend/requirements.txt
+++ b/code/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+passlib[bcrypt]
+mysqlclient
+pydantic

--- a/code/backend/schemas.py
+++ b/code/backend/schemas.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class UserLogin(UserBase):
+    password: str
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/code/frontend/.gitignore
+++ b/code/frontend/.gitignore
@@ -1,1 +1,2 @@
-.DS_Store
+node_modules
+.next

--- a/code/frontend/README.md
+++ b/code/frontend/README.md
@@ -1,0 +1,14 @@
+# Frontend
+
+A Next.js frontend with pages for registration and login.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/code/frontend/next-env.d.ts
+++ b/code/frontend/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/code/frontend/package.json
+++ b/code/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "redis-supreme-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/code/frontend/pages/index.tsx
+++ b/code/frontend/pages/index.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Redis Supreme</h1>
+      <ul>
+        <li><Link href="/register">Register</Link></li>
+        <li><Link href="/login">Login</Link></li>
+      </ul>
+    </div>
+  )
+}

--- a/code/frontend/pages/login.tsx
+++ b/code/frontend/pages/login.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export default function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('http://localhost:8000/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    const data = await res.json()
+    setMessage(data.message)
+  }
+  return (
+    <form onSubmit={handleSubmit}>
+      <h1>Login</h1>
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+      <p>{message}</p>
+    </form>
+  )
+}

--- a/code/frontend/pages/register.tsx
+++ b/code/frontend/pages/register.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+export default function Register() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch('http://localhost:8000/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+  }
+  return (
+    <form onSubmit={handleSubmit}>
+      <h1>Register</h1>
+      <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+  )
+}

--- a/code/frontend/tsconfig.json
+++ b/code/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with MySQL-ready database setup
- add CRUD helpers and Pydantic schemas
- scaffold Next.js frontend with register and login pages
- document setup steps for both parts

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b5baaad7c832089e5db13f1894cbf