### PR TITLE
Add tests and migration docs

### DIFF
--- a/code/backend/README.md
+++ b/code/backend/README.md
@@ -18,6 +18,23 @@ A FastAPI backend providing registration and login endpoints.
    uvicorn app:app --reload
    ```
 
+## Migrations
+
+Alembic manages database schema migrations. The configuration lives in
+`alembic.ini` and migration scripts reside under `database/migrations`.
+
+Create a new migration after modifying models:
+
+```bash
+alembic revision --autogenerate -m "describe changes"
+```
+
+Apply migrations to the database:
+
+```bash
+alembic upgrade head
+```
+
 ## Database
 
 ### SQLite

--- a/code/backend/requirements.txt
+++ b/code/backend/requirements.txt
@@ -6,3 +6,5 @@ mysqlclient
 pydantic
 python-dotenv
 alembic
+pytest
+httpx

--- a/code/backend/tests/test_auth.py
+++ b/code/backend/tests/test_auth.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+# Use a separate SQLite file for tests
+os.environ["DATABASE_URL"] = "sqlite:///./test_temp.db"
+
+# Ensure the backend package is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import app, get_db
+from database import Base, engine, SessionLocal
+
+# Ensure a clean database for each test
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+# Override the dependency to use the same testing session
+def override_get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def test_register_success():
+    response = client.post("/register", json={"username": "alice", "password": "secret"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "alice"
+    assert "id" in data
+
+
+def test_register_existing_user():
+    client.post("/register", json={"username": "bob", "password": "pass"})
+    response = client.post("/register", json={"username": "bob", "password": "pass"})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Username already registered"
+
+
+def test_login_success():
+    client.post("/register", json={"username": "carol", "password": "carolpass"})
+    response = client.post("/login", json={"username": "carol", "password": "carolpass"})
+    assert response.status_code == 200
+    assert response.json() == {"message": "Login successful"}
+
+
+def test_login_invalid_credentials():
+    client.post("/register", json={"username": "dan", "password": "password"})
+    response = client.post("/login", json={"username": "dan", "password": "wrong"})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid credentials"


### PR DESCRIPTION
## Summary
- document how to run migrations with Alembic
- add pytest and httpx as backend dependencies
- add unit tests for registration and login endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b64e79a788320953c5857bb69b243