### PR TITLE
Align env and Alembic paths

### DIFF
--- a/code/backend/README.md
+++ b/code/backend/README.md
@@ -10,7 +10,7 @@ A FastAPI backend providing registration and login endpoints.
    pip install -r requirements.txt
    ```
 
-2. Configure the database by creating a `.env` file or setting the `DATABASE_URL` environment variable.
+2. Configure the database by creating a `.env` file **in this directory** or setting the `DATABASE_URL` environment variable.
    The provided `.env` file defaults to SQLite `./database/test.db`.
 3. Start the server:
 
@@ -27,7 +27,7 @@ Store the database in code/backend/database
 ### Migrations
 
 Alembic manages database schema migrations. The configuration lives in
-`alembic.ini` and migration scripts reside under `database/migrations`.
+`alembic.ini` (located in this directory) and migration scripts reside under `database/migrations`.
 
 Create a new migration after modifying models:
 

--- a/code/backend/database.py
+++ b/code/backend/database.py
@@ -2,6 +2,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from the .env file located in the backend directory
+load_dotenv(Path(__file__).resolve().parent / ".env")
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
 


### PR DESCRIPTION
## Summary
- load `.env` from backend folder in `database.py`
- document `.env` and `alembic.ini` locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6d8b75188320b18015dc218386ce