### PR TITLE
Fix migration docs and env sample

### DIFF
--- a/code/backend/.env.sample
+++ b/code/backend/.env.sample
@@ -1,5 +1,7 @@
 DATABASE=sqlite3
-DATABASE_URL=
+# Set a valid SQLAlchemy URL for Alembic migrations.
+# By default use the bundled SQLite database.
+DATABASE_URL=sqlite:///./database/test.db
 #DATABASE=mysql
 #MYSQL_HOST=127.0.0.1
 #MYSQL_PORT=3306

--- a/code/backend/README.md
+++ b/code/backend/README.md
@@ -10,8 +10,9 @@ A FastAPI backend providing registration and login endpoints.
    pip install -r requirements.txt
    ```
 
-2. Configure the database by creating a `.env` file **in this directory** or setting the `DATABASE_URL` environment variable.
-   The provided `.env` file defaults to SQLite `./database/test.db`.
+2. Configure the database connection:
+   - Copy `.env.sample` to `.env` and modify if needed, or set the `DATABASE_URL` environment variable.
+   - The default configuration uses SQLite `./database/test.db`.
 3. Start the server:
 
    ```bash


### PR DESCRIPTION
## Summary
- set DATABASE_URL default in `.env.sample`
- clarify migration setup instructions in README

## Testing
- `cd code/backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_685b7497f11483208efa735c2dd66410