### PR TITLE
Fix SQLAlchemy import and ensure db paths

### DIFF
--- a/code/backend/database/__init__.py
+++ b/code/backend/database/__init__.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 import os
 from pathlib import Path
 from dotenv import load_dotenv
@@ -8,7 +7,7 @@ from dotenv import load_dotenv
 # Load environment variables from the .env file located in the backend directory
 load_dotenv(Path(__file__).resolve().parent / ".env")
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./database/test.db")
 
 engine = create_engine(
     DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}

--- a/code/backend/schemas.py
+++ b/code/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class UserBase(BaseModel):
     username: str
@@ -12,5 +12,4 @@ class UserLogin(UserBase):
 class User(UserBase):
     id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/code/backend/tests/test_auth.py
+++ b/code/backend/tests/test_auth.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-# Use a separate SQLite file for tests
-os.environ["DATABASE_URL"] = "sqlite:///./test_temp.db"
+# Use a separate SQLite file for tests inside the database directory
+os.environ["DATABASE_URL"] = "sqlite:///./code/backend/database/test_temp.db"
 
 # Ensure the backend package is on the Python path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -20,6 +20,8 @@ def setup_db():
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
+    # Remove the temporary database file
+    Path("code/backend/database/test_temp.db").unlink(missing_ok=True)
 
 # Override the dependency to use the same testing session
 def override_get_db():


### PR DESCRIPTION
## Summary
- update SQLAlchemy declarative_base import and default DB path
- switch to Pydantic `ConfigDict` for models
- ensure tests create their DB under `code/backend/database`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685b8364e6dc8320b4610a5ab82e3700