### PR TITLE
Make API base URL configurable for Next.js frontend

### DIFF
--- a/code/frontend/.env.sample
+++ b/code/frontend/.env.sample
@@ -1,0 +1,2 @@
+# Base URL for backend API
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/code/frontend/.gitignore
+++ b/code/frontend/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+.env.local

--- a/code/frontend/README.md
+++ b/code/frontend/README.md
@@ -12,3 +12,9 @@ A Next.js frontend with pages for registration and login.
    ```bash
    npm run dev
    ```
+
+### Configuration
+
+API requests use the `NEXT_PUBLIC_API_URL` environment variable to determine the
+backend base URL. Copy `.env.sample` to `.env.local` and adjust if your backend
+is running elsewhere.

--- a/code/frontend/lib/api.ts
+++ b/code/frontend/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';

--- a/code/frontend/pages/login.tsx
+++ b/code/frontend/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import { API_BASE_URL } from '../lib/api'
 
 export default function Login() {
   const [username, setUsername] = useState('')
@@ -8,7 +9,7 @@ export default function Login() {
   const router = useRouter()
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const res = await fetch('http://localhost:8000/login', {
+    const res = await fetch(`${API_BASE_URL}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/code/frontend/pages/register.tsx
+++ b/code/frontend/pages/register.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
+import { API_BASE_URL } from '../lib/api'
 
 export default function Register() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await fetch('http://localhost:8000/register', {
+    await fetch(`${API_BASE_URL}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })


### PR DESCRIPTION
## Summary
- allow frontend to configure API base URL via `NEXT_PUBLIC_API_URL`
- add helper `lib/api.ts`
- document configuration in frontend README
- provide `.env.sample` and ignore `.env.local`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b8d1e5d348320b86227f518e9ae44