### PR TITLE
Unify env file usage

### DIFF
--- a/code/frontend/.gitignore
+++ b/code/frontend/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .next
-.env.local
+.env

--- a/code/frontend/README.md
+++ b/code/frontend/README.md
@@ -16,5 +16,5 @@ A Next.js frontend with pages for registration and login.
 ### Configuration
 
 API requests use the `NEXT_PUBLIC_API_URL` environment variable to determine the
-backend base URL. Copy `.env.sample` to `.env.local` and adjust if your backend
-is running elsewhere.
+backend base URL. Copy `.env.sample` to `.env` and adjust if your backend is
+running elsewhere.


### PR DESCRIPTION
## Summary
- point frontend docs to `.env` like backend
- ignore `.env` instead of `.env.local`

## Testing
- `pip install -r requirements.txt`
- `pytest code/backend/tests/test_auth.py` *(fails: sqlite3 OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_685b930850a883209d8275918aa23a83